### PR TITLE
Add visualization script for trained models

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ Relevant training metrics are logged to the `runs/` directory. To view them in T
 tensorboard --logdir runs
 ```
 
+### 4. Visualizing a Trained Model
+To watch a trained agent play Pong for a given number of steps, place the model
+inside the `models/trained/` directory and adjust the parameters at the top of
+`src/render.py`:
+```bash
+python -m src.render
+```
+
 ## Background & Implementation
 The implementation in this project is directly based on the 2013 paper by Mnih et al. "Playing Atari with Deep Reinforcement Learning", who were the first to successfully use a deep learning model to learn to play Atari 2600 games directly from visual input. The theory is furthermore based on OpenAI's [Spinning Up in Deep RL](https://spinningup.openai.com/en/latest/index.html).
 

--- a/src/evaluator.py
+++ b/src/evaluator.py
@@ -55,4 +55,5 @@ class Evaluator:
             frames_to_stack = self.frame_test_set[idx - stack_size:idx]
             frame_stack = torch.cat(frames_to_stack, dim=0).to(self.device)
             with torch.no_grad():
-                max_qs.append(torch.max(agent.online_net(frame_stack)).item())        return float(np.mean(max_qs))
+                max_qs.append(torch.max(agent.online_net(frame_stack)).item())
+        return float(np.mean(max_qs))

--- a/src/render.py
+++ b/src/render.py
@@ -1,23 +1,62 @@
-import gymnasium as gym
-import ale_py
+"""Utility script to render a trained DQN agent playing Pong."""
+
 import os
+
+import ale_py
+import gymnasium as gym
 import torch
+from torchvision.transforms import v2
 
 from src.networks import QNetwork
+from src.utils import FrameBuffer
+
 
 gym.register_envs(ale_py)
 
-env = gym.make("ALE/Pong-v5")
 
-model_dir = "models/trained"
-model_name = "trained_base_and_target_networks.pth"
-model_path = os.path.join(model_dir, model_name)
-state_dict = torch.load(model_path)
+# Parameters controlling visualization
+MODEL_NAME = "trained_base_and_target_networks.pth"
+STEPS = 1000
 
-dqn = QNetwork(env.action_space.n)
-dqn.load_state_dict(state_dict["model_state"])
 
-obs, info = env.reset()
-for _ in range(100):
-    pass
+if __name__ == "__main__":
+    model_path = os.path.join("models", "trained", MODEL_NAME)
+    if not os.path.isfile(model_path):
+        raise FileNotFoundError(model_path)
+
+    env = gym.make("ALE/Pong-v5", render_mode="human")
+    state_dict = torch.load(model_path, map_location="cpu")
+
+    qnet = QNetwork(env.action_space.n)
+    if "model_state" in state_dict:
+        qnet.load_state_dict(state_dict["model_state"])
+    else:
+        qnet.load_state_dict(state_dict)
+    qnet.eval()
+
+    transforms = v2.Compose(
+        [v2.Grayscale(), v2.ToDtype(torch.float32, scale=True), v2.Resize((84, 84))]
+    )
+    frame_buffer = FrameBuffer(4, "cpu", transforms)
+
+    obs, _ = env.reset()
+    frame_buffer.append(obs)
+    for _ in range(STEPS):
+        if len(frame_buffer) == 4:
+            state = frame_buffer.preprocess().unsqueeze(0)
+            with torch.no_grad():
+                action = int(torch.argmax(qnet(state)))
+        else:
+            action = env.action_space.sample()
+
+        obs, _, terminated, truncated, _ = env.step(action)
+        env.render()
+        frame_buffer.append(obs)
+        if terminated or truncated:
+            frame_buffer.clear()
+            obs, _ = env.reset()
+            frame_buffer.append(obs)
+
+    env.close()
+
 


### PR DESCRIPTION
## Summary
- add a rendering script to play a saved model
- document how to visualize a trained model
- fix typo in evaluator
- clarify where model files must be stored
- use constants instead of CLI arguments for rendering

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686e87a0319483229e25b54bcf9cfbcf